### PR TITLE
fix(lists): handle missing list-style-type in hasCompatibleStyle toggle check

### DIFF
--- a/modules/hugerte/src/plugins/lists/main/ts/actions/ToggleList.ts
+++ b/modules/hugerte/src/plugins/lists/main/ts/actions/ToggleList.ts
@@ -192,6 +192,9 @@ const getSelectedTextBlocks = (editor: Editor, rng: Range, root: Node): HTMLElem
 };
 
 const hasCompatibleStyle = (dom: DOMUtils, sib: Element, detail: ListDetail): boolean => {
+  if (!('list-style-type' in detail)) {
+    return true;
+  }
   const sibStyle = dom.getStyle(sib, 'list-style-type');
   const detailStyle = detail['list-style-type'] ?? '';
   return sibStyle === detailStyle;


### PR DESCRIPTION
With a single non-default list style configured, the toggle button would only remove the custom style attribute rather than eliminating the list entirely. This is because commit 812cb0110e (#138) replaced the `!hasListStyleDetail(detail)` check in `toggleSingleList` with `hasCompatibleStyle`, which does not account for the case where `detail` has no `list-style-type` key.

This fix makes `hasCompatibleStyle` return `true` when `detail` has no `list-style-type` key, treating the absence of a style preference as compatible with any existing style.

1. Closes #210
2. No breaking changes.
3. This is a test update. The `hasCompatibleStyle` function in `ToggleList.ts` did not account for the case introduced by #138, causing the TINY-8721 Headless Tests to fail.
4. No new tests added. Existing tests (`AdvlistOptionsAndToolbarTest`) already cover this scenario and will pass with this fix.