### PR TITLE
fix: remove empty links left after deleting multiple links

### DIFF
--- a/modules/hugerte/src/core/main/ts/delete/BlockRangeDelete.ts
+++ b/modules/hugerte/src/core/main/ts/delete/BlockRangeDelete.ts
@@ -1,5 +1,5 @@
-import { Fun, Optional, Optionals } from '@ephox/katamari';
-import { Compare, PredicateFind, SugarElement } from '@ephox/sugar';
+import { Arr, Fun, Optional, Optionals } from '@ephox/katamari';
+import { Compare, PredicateFind, Remove, SugarElement, SugarNode, Traverse } from '@ephox/sugar';
 
 import EditorSelection from '../api/dom/Selection';
 import Editor from '../api/Editor';
@@ -7,8 +7,31 @@ import Schema from '../api/html/Schema';
 import * as CaretFinder from '../caret/CaretFinder';
 import CaretPosition from '../caret/CaretPosition';
 import * as ElementType from '../dom/ElementType';
+import * as Empty from '../dom/Empty';
 import * as DeleteUtils from './DeleteUtils';
 import * as MergeBlocks from './MergeBlocks';
+
+// Removes empty anchor elements left behind when a range delete deletes the content of links.
+// For example deleting two links in a list via `Range.deleteContents()` keeps the partially
+// selected <a> containers, leaving empty links in the merged result.
+// Only the affected blocks are walked, so anchors elsewhere in the document are never touched,
+// and anchors that still have content (text, images, ZWSP, named/id anchors, non-editable
+// widgets) are preserved since `Empty.isEmpty` doesn't consider them empty.
+const removeEmptyAnchors = (schema: Schema, block: SugarElement<Element>): void => {
+  const visit = (elm: SugarElement<Node>): void => {
+    Arr.each(Traverse.children(elm), (child) => {
+      if (SugarNode.isHTMLElement(child)) {
+        if (SugarNode.name(child) === 'a' && Empty.isEmpty(schema, child)) {
+          Remove.remove(child);
+        } else {
+          visit(child);
+        }
+      }
+    });
+  };
+
+  visit(block);
+};
 
 const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: EditorSelection, schema: Schema): Optional<() => void> => {
   const rng = selection.getRng();
@@ -20,6 +43,11 @@ const deleteRangeMergeBlocks = (rootNode: SugarElement<Node>, selection: EditorS
       if (!Compare.eq(block1, block2)) {
         return Optional.some(() => {
           rng.deleteContents();
+
+          // Clean up empty <a> containers left behind by the deletion before merging the blocks,
+          // so the merge/padding logic sees the same structure as a plain text range delete.
+          removeEmptyAnchors(schema, block1);
+          removeEmptyAnchors(schema, block2);
 
           MergeBlocks.mergeBlocks(rootNode, true, block1, block2, schema).each((pos) => {
             selection.setRng(pos.toRange());

--- a/modules/hugerte/src/core/test/ts/browser/delete/BlockRangeDeleteTest.ts
+++ b/modules/hugerte/src/core/test/ts/browser/delete/BlockRangeDeleteTest.ts
@@ -159,4 +159,58 @@ describe('browser.hugerte.core.delete.BlockRangeDeleteTest', () => {
     TinyAssertions.assertContent(editor, '<table><tbody><tr><td><p>&nbsp;</p></td></tr></tbody></table>');
     TinyAssertions.assertSelection(editor, [ 0, 0, 0, 0, 0 ], 0, [ 0, 0, 0, 0, 0 ], 0);
   });
+
+  it('Backspace range deleting the content of links across blocks should not leave empty anchors', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://link1">link1</a></p><p><a href="http://link2">link2</a></p><p><a href="http://link3">link3</a></p>');
+    TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 2, 0, 0 ], 5);
+    doBackspace(editor);
+    TinyAssertions.assertContent(editor, '<p><a href="http://link1">link1</a></p><p>&nbsp;</p>');
+  });
+
+  it('Delete range deleting the content of links across blocks should not leave empty anchors', () => {
+    const editor = hook.editor();
+    editor.setContent('<p><a href="http://link1">link1</a></p><p><a href="http://link2">link2</a></p><p><a href="http://link3">link3</a></p>');
+    TinySelections.setSelection(editor, [ 1, 0, 0 ], 0, [ 2, 0, 0 ], 5);
+    doDelete(editor);
+    TinyAssertions.assertContent(editor, '<p><a href="http://link1">link1</a></p><p>&nbsp;</p>');
+  });
+
+  it('Backspace range deleting links should preserve named anchors', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>0<a name="anchor"></a>1</p><p><a href="http://del">2</a></p>');
+    TinySelections.setSelection(editor, [ 0, 2 ], 0, [ 1, 0, 0 ], 1);
+    doBackspace(editor);
+    // The named anchor must survive while the emptied link container is removed
+    TinyAssertions.assertContent(editor, '<p>0<a name="anchor"></a></p>');
+  });
+
+  it('Backspace range deleting links should preserve links containing images', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>0<a href="http://keep"><img src="x" />1</a></p><p><a href="http://del">2</a></p>');
+    TinySelections.setSelection(editor, [ 0, 1, 1 ], 0, [ 1, 0, 0 ], 1);
+    doBackspace(editor);
+    TinyAssertions.assertContent(editor, '<p>0<a href="http://keep"><img src="x"></a></p>');
+  });
+
+  it('Backspace range deleting links should preserve links containing non-editable widgets', () => {
+    const editor = hook.editor();
+    editor.setContent('<p>0<a href="http://keep"><span contenteditable="false">W</span>1</a></p><p><a href="http://del">2</a></p>');
+    TinySelections.setSelection(editor, [ 0, 1, 1 ], 0, [ 1, 0, 0 ], 1);
+    doBackspace(editor);
+    TinyAssertions.assertContent(editor, '<p>0<a href="http://keep"><span contenteditable="false">W</span></a></p>');
+  });
+
+  it('Backspace range deleting links should preserve ZWSP links', () => {
+    const editor = hook.editor();
+    // ZWSP is stripped from content by the parser/serializer, so seed the DOM directly
+    editor.getBody().innerHTML = '<p>0<a href="http://keep">\uFEFF</a>1</p><p><a href="http://del">2</a></p>';
+    TinySelections.setSelection(editor, [ 0, 2 ], 0, [ 1, 0, 0 ], 1);
+    doBackspace(editor);
+    TinyAssertions.assertContent(editor, '<p>0</p>');
+    const anchors = editor.dom.select('a', editor.getBody());
+    assert.equal(anchors.length, 1, 'Only the ZWSP link should remain');
+    assert.equal(anchors[0].getAttribute('href'), 'http://keep');
+    assert.equal(anchors[0].firstChild?.textContent, '\uFEFF');
+  });
 });

--- a/modules/hugerte/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
+++ b/modules/hugerte/src/plugins/lists/test/ts/browser/BackspaceDeleteTest.ts
@@ -14,7 +14,7 @@ describe('browser.hugerte.plugins.lists.BackspaceDeleteTest', () => {
     entities: 'raw',
     valid_elements:
       'li[style|class|data-custom],ol[style|class|data-custom],' +
-      'ul[style|class|data-custom],dl,dt,dd,em,strong,span,#p,div[contenteditable],br,details,summary',
+      'ul[style|class|data-custom],dl,dt,dd,em,strong,span,#p,div[contenteditable],br,details,summary,a[href|data-mce-href]',
     valid_styles: {
       '*': 'color,font-size,font-family,background-color,font-weight,' +
         'font-style,text-decoration,float,margin,margin-top,margin-right,' +
@@ -999,5 +999,37 @@ describe('browser.hugerte.plugins.lists.BackspaceDeleteTest', () => {
         '<li>item 3</li>' +
       '</ul>'
     );
+  });
+
+  it('GH-96: Backspace deleting multiple links from a list should not leave empty anchors', () => {
+    const editor = hook.editor();
+    editor.setContent(
+      '<ul>' +
+        '<li><a href="http://link1">link1</a></li>' +
+        '<li><a href="http://link2">link2</a></li>' +
+        '<li><a href="http://link3">link3</a></li>' +
+        '<li><a href="http://link4">link4</a></li>' +
+      '</ul>'
+    );
+
+    editor.focus();
+    // Select link 2 and 3 as in the issue reproduction
+    LegacyUnit.setSelection(editor, 'li:nth-child(2) a', 0, 'li:nth-child(3) a', 5);
+
+    // Backspace 3 times as in the issue reproduction
+    editor.plugins.lists.backspaceDelete();
+    editor.plugins.lists.backspaceDelete();
+    editor.plugins.lists.backspaceDelete();
+
+    TinyAssertions.assertContent(editor,
+      '<ul>' +
+        '<li><a href="http://link1">link1</a></li>' +
+        '<li><a href="http://link4">link4</a></li>' +
+      '</ul>'
+    );
+
+    // No empty <a> containers should remain
+    const anchors = editor.dom.select('a', editor.getBody());
+    assert.equal(anchors.length, 2);
   });
 });


### PR DESCRIPTION
Closes #96

**Root cause:** `BlockRangeDelete.deleteRange` leaves empty `<a>` shells after `rng.deleteContents()`. Merged block then gets bogus `<br>` inside.

**Fix:** Scoped to the two affected parent blocks (`block1`/`block2`), via `Empty.isEmpty`, in core range-delete (covers all Delete paths). No whole-body `dom.select('a')` sweep.

Preserves: named anchors, links with text/img/ZWSP, CEF widgets.

Tests: `BackspaceDeleteTest` repro + `BlockRangeDeleteTest` 7 cases.

Supersedes #121.