### PR TITLE
feat(preview): add preview_content_callback to customize preview output

### DIFF
--- a/modules/hugerte/src/core/main/ts/api/OptionTypes.ts
+++ b/modules/hugerte/src/core/main/ts/api/OptionTypes.ts
@@ -336,6 +336,7 @@ export interface EditorOptions extends NormalizedEditorOptions {
   pad_empty_with_br: boolean;
   paste_as_text: boolean;
   preview_styles: string;
+  preview_content_callback?: (content: string) => string;
   readonly: boolean;
   removed_menuitems: string;
   sandbox_iframes: boolean;

--- a/modules/hugerte/src/plugins/preview/main/ts/Plugin.ts
+++ b/modules/hugerte/src/plugins/preview/main/ts/Plugin.ts
@@ -2,9 +2,11 @@ import PluginManager from 'hugerte/core/api/PluginManager';
 
 import * as Commands from './api/Commands';
 import * as Buttons from './ui/Buttons';
+import * as Options from './api/Options';
 
 export default (): void => {
   PluginManager.add('preview', (editor) => {
+    Options.register(editor);
     Commands.register(editor);
     Buttons.register(editor);
   });

--- a/modules/hugerte/src/plugins/preview/main/ts/api/Options.ts
+++ b/modules/hugerte/src/plugins/preview/main/ts/api/Options.ts
@@ -11,10 +11,21 @@ const getContentStyle = option('content_style');
 const shouldUseContentCssCors = option('content_css_cors');
 const getBodyClass = option('body_class');
 const getBodyId = option('body_id');
+const getPreviewContentCallback = option('preview_content_callback');
+
+const register = (editor: Editor): void => {
+  const registerOption = editor.options.register;
+
+  registerOption('preview_content_callback', {
+    processor: 'function'
+  });
+};
 
 export {
   getContentStyle,
   shouldUseContentCssCors,
   getBodyClass,
-  getBodyId
+  getBodyId,
+  getPreviewContentCallback,
+  register
 };

--- a/modules/hugerte/src/plugins/preview/main/ts/core/IframeContent.ts
+++ b/modules/hugerte/src/plugins/preview/main/ts/core/IframeContent.ts
@@ -41,6 +41,23 @@ const getPreviewHtml = (editor: Editor): string => {
   const directionality = editor.getBody().dir;
   const dirAttr = directionality ? ' dir="' + encode(directionality) + '"' : '';
 
+  let content = editor.getContent();
+  const callback = Options.getPreviewContentCallback(editor);
+  if (typeof callback === 'function') {
+    try {
+      const result = callback(content);
+      if (typeof result === 'string') {
+        content = result;
+      } else if (result !== undefined) {
+        // eslint-disable-next-line no-console
+        console.warn('preview_content_callback should return a string, got', typeof result);
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn('preview_content_callback threw an error:', e);
+    }
+  }
+
   const previewHtml = (
     '<!DOCTYPE html>' +
     '<html>' +
@@ -48,7 +65,7 @@ const getPreviewHtml = (editor: Editor): string => {
     headHtml +
     '</head>' +
     '<body id="' + encode(bodyId) + '" class="mce-content-body ' + encode(bodyClass) + '"' + dirAttr + '>' +
-    editor.getContent() +
+    content +
     preventClicksOnLinksScript +
     '</body>' +
     '</html>'


### PR DESCRIPTION
Closes #213

Allows customizing preview HTML (e.g. filling template variables like `{{foo}}`) without modifying editor content.

```js
hugerte.init({
  preview_content_callback: (html) => html.replaceAll('{{foo}}', user.foo)
})
```

Callback receives editor `getContent()` HTML, must return string. Errors are caught and warned via `console.warn`, falling back to original content. Preview is sandboxed.

Additive, no breaking change.