### PR TITLE
fix(tests): update headless test expectations for Chrome hex casing and HugeRTE rebrand

### DIFF
--- a/modules/hugerte/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/hugerte/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -119,8 +119,6 @@ describe('browser.hugerte.plugins.autoresize.AutoresizePluginTest', () => {
       // Note: Use a min-height here to account for different browsers rendering broken images differently
       editor.setContent('<div style="min-height: 35px;"><img src="#" /></div><div style="height: 5500px;"></div>');
       await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5585), 10, 3000);
-      // Update the img element to load an image. The old TinyMCE CDN logo URL no longer exists (404),
-      // so load an inline 100x100 image instead of relying on an external host.
       const image = editor.dom.select('img')[0];
       editor.dom.setAttrib(image, 'src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAAtUlEQVR4nO3QQQkAIADAQFtbwQq2tYIfGcLBAowbc21dNvKDj4IFC1YeLFiw8mDBgpUHCxasPFiwYOXBggUrDxYsWHmwYMHKgwULVh4sWLDyYMGClQcLFqw8WLBg5cGCBSsPFixYebBgwcqDBQtWHixYsPJgwYKVBwsWrDxYsGDlwYIFKw8WLFh5sGDByoMFC1YeLFiw8mDBgpUHCxasPFiwYOXBggUrDxYsWHmwYMHKgwXrTQd0LEUjcQBC0QAAAABJRU5ErkJggg==');
       // Content height + div image height (100px img + 6px line box) + bottom margin = 5656

--- a/modules/hugerte/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
+++ b/modules/hugerte/src/plugins/autoresize/test/ts/browser/AutoresizePluginTest.ts
@@ -119,12 +119,13 @@ describe('browser.hugerte.plugins.autoresize.AutoresizePluginTest', () => {
       // Note: Use a min-height here to account for different browsers rendering broken images differently
       editor.setContent('<div style="min-height: 35px;"><img src="#" /></div><div style="height: 5500px;"></div>');
       await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5585), 10, 3000);
-      // Update the img element to load an image
+      // Update the img element to load an image. The old TinyMCE CDN logo URL no longer exists (404),
+      // so load an inline 100x100 image instead of relying on an external host.
       const image = editor.dom.select('img')[0];
-      editor.dom.setAttrib(image, 'src', 'http://moxiecode.cachefly.net/hugerte/v9/images/logo.png');
-      // Content height + div image height (84px) + bottom margin = 5634
-      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5634), 10, 3000);
-      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5634), 10, 3000);
+      editor.dom.setAttrib(image, 'src', 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAAtUlEQVR4nO3QQQkAIADAQFtbwQq2tYIfGcLBAowbc21dNvKDj4IFC1YeLFiw8mDBgpUHCxasPFiwYOXBggUrDxYsWHmwYMHKgwULVh4sWLDyYMGClQcLFqw8WLBg5cGCBSsPFixYebBgwcqDBQtWHixYsPJgwYKVBwsWrDxYsGDlwYIFKw8WLFh5sGDByoMFC1YeLFiw8mDBgpUHCxasPFiwYOXBggUrDxYsWHmwYMHKgwXrTQd0LEUjcQBC0QAAAABJRU5ErkJggg==');
+      // Content height + div image height (100px img + 6px line box) + bottom margin = 5656
+      await Waiter.pTryUntil('wait for editor content height', () => assertEditorContentApproxHeight(editor, 5656), 10, 3000);
+      await Waiter.pTryUntil('wait for editor height', () => assertEditorHeightAbove(editor, 5656), 10, 3000);
     });
 
     it('TBA: Editor size content set to 10 and autoresize_bottom_margin set to 100', async () => {

--- a/modules/hugerte/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
+++ b/modules/hugerte/src/plugins/help/test/ts/browser/DialogKeyboardNavTest.ts
@@ -78,8 +78,7 @@ describe('browser.hugerte.plugins.help.DialogKeyboardNavTest', () => {
       await pAssertFocusOnItem(`Installed Plugins link:${installedPlugin}`, `a[href*="${installedPlugin}"]`);
       pressTabKey(editor);
     }
-    await pAssertFocusOnItem('Premium Plugins link:Learn more...', `a[href*="/pricing"]`);
-    pressTabKey(editor);
+    // HugeRTE no longer lists premium plugins, so focus moves directly to the Close button
     await pAssertFocusOnItem('Close Button', '.tox-button:contains("Close")');
     pressTabKey(editor);
     await pAssertFocusOnItem('"x" Close Button', '.tox-button[data-mce-name="close"]');

--- a/modules/hugerte/src/plugins/help/test/ts/browser/PluginTabsOrderTest.ts
+++ b/modules/hugerte/src/plugins/help/test/ts/browser/PluginTabsOrderTest.ts
@@ -51,9 +51,4 @@ describe('browser.hugerte.plugins.help.PluginTabsOrderTest', () => {
     const editor = hook.editor();
     await pTestPluginItems('Installed Plugins', editor, selectors.pluginsTabLists.installed);
   });
-
-  it('TINY-9019: Available Plugin Lists are alphabetically ordered', async () => {
-    const editor = hook.editor();
-    await pTestPluginItems('Available Plugins', editor, selectors.pluginsTabLists.available);
-  });
 });

--- a/modules/hugerte/src/plugins/help/test/ts/module/Selectors.ts
+++ b/modules/hugerte/src/plugins/help/test/ts/module/Selectors.ts
@@ -4,7 +4,6 @@ export const selectors = {
   pluginsTab: '[role="tab"]:contains(Plugins)',
   pluginsTabLists: {
     installed: '[role=document] div:eq(0) ul',
-    available: '[role=document] div:eq(1) ul',
     readMoreClass: 'tox-help__more-link'
   }
 };

--- a/modules/hugerte/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
+++ b/modules/hugerte/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
@@ -16,7 +16,6 @@ describe('browser.hugerte.themes.silver.editor.ForceHexColorTest', () => {
         TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length + 1);
         editor.execCommand('mceApplyTextcolor', 'forecolor' as any, appliedColor);
         TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
-        // Chrome (v150+) lowercases hex colors when serializing the style attribute, but the editor-serialized `data-mce-style` is left untouched
         TinyAssertions.assertContent(editor, `<p><span style="color: ${expectedColor.toLowerCase()};">colour me</span></p>`);
       },
       /** Apply color using the 'forecolor' part of the toolbar. */

--- a/modules/hugerte/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
+++ b/modules/hugerte/src/themes/silver/test/ts/browser/editor/ForceHexColorTest.ts
@@ -16,7 +16,8 @@ describe('browser.hugerte.themes.silver.editor.ForceHexColorTest', () => {
         TinySelections.setSelection(editor, [ 0, 0 ], 0, [ 0, 0 ], 'color me'.length + 1);
         editor.execCommand('mceApplyTextcolor', 'forecolor' as any, appliedColor);
         TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
-        TinyAssertions.assertContent(editor, `<p><span style="color: ${expectedColor};">colour me</span></p>`);
+        // Chrome (v150+) lowercases hex colors when serializing the style attribute, but the editor-serialized `data-mce-style` is left untouched
+        TinyAssertions.assertContent(editor, `<p><span style="color: ${expectedColor.toLowerCase()};">colour me</span></p>`);
       },
       /** Apply color using the 'forecolor' part of the toolbar. */
       usingToolbar: async () => {
@@ -25,7 +26,7 @@ describe('browser.hugerte.themes.silver.editor.ForceHexColorTest', () => {
         await TinyUiActions.pWaitForUi(editor, '.tox-swatches');
         TinyUiActions.clickOnUi(editor, `div[data-mce-color="${appliedColor}"]`);
         TinyAssertions.assertContentPresence(editor, { [`span[data-mce-style="color: ${expectedColor};"]`]: 1 });
-        TinyAssertions.assertContent(editor, `<p><span style="color: ${expectedColor};">colour me</span></p>`);
+        TinyAssertions.assertContent(editor, `<p><span style="color: ${expectedColor.toLowerCase()};">colour me</span></p>`);
       },
     };
   };

--- a/modules/hugerte/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
+++ b/modules/hugerte/src/themes/silver/test/ts/browser/statusbar/StatusbarTest.ts
@@ -28,11 +28,8 @@ describe('browser.hugerte.themes.silver.statusbar.StatusbarTest', () => {
       classes: [ arr.has('tox-statusbar__branding') ],
       children: [
         s.element('a', {
-          attrs: {
-            'aria-label': str.is('Powered by Tiny')
-          },
           children: [
-            s.element('svg', {})
+            s.text(str.is('Powered by HugeRTE'))
           ]
         })
       ]


### PR DESCRIPTION
## What

Updates test **expectations only** (no production / sanitization logic changed) so the headless browser suite matches current Chrome and HugeRTE-rebrand reality. Touched files were the 10 known failures (ForceHexColor 6, Statusbar 4) plus the optional help-dialog/autoresize cases were also failing locally.

## Changes

- **ForceHexColorTest** (6 tests): Chrome v150+ lowercases hex colors when serializing the DOM `style` attribute (e.g. `#323c46`), while the editor-serialized `data-mce-style` attribute keeps the uppercase form. The helper now lowercases only the expected color in the content assertion; swatch click values and `data-mce-style` presence checks stay uppercase (swatches are normalized to uppercase by `anyToHex`).
- **StatusbarTest** (4 tests): the branding link no longer has an `aria-label` or SVG logo — it renders text "Powered by HugeRTE" (`I18n.translate(['Powered by {0}', 'HugeRTE'])`). Updated the `brandingSpec` structure check.
- **DialogKeyboardNavTest**: the rebranded help dialog no longer lists premium plugins, so after the installed-plugin links focus goes straight to Close. Removed the stale `a[href*="/pricing"]` check.
- **PluginTabsOrderTest** + **Selectors.ts**: the "Available Plugins" (premium) list no longer exists; removed that test case and its unused selector.
- **AutoresizePluginTest**: the old TinyMCE CDN logo URL (`moxiecode.cachefly.net/...`) returns 404, so the "async loaded content" test now loads an inline 100×100 data-URI PNG and expects the corresponding height (5656px).

## Verification

Ran the touched test files locally in `chrome-headless` via bedrock — all pass:

```
ForceHexColorTest: 9/9
StatusbarTest:     8/8
DialogKeyboardNav: 4/4
PluginTabsOrder:   2/2
Autoresize:       14/14
```