### PR TITLE
fix(ci): include rollup bundles in the ci build (root cause of flaky PlaceholderTest TINY-3917)

### DIFF
--- a/modules/hugerte/src/plugins/lists/test/ts/browser/PluginScriptLoadingTest.ts
+++ b/modules/hugerte/src/plugins/lists/test/ts/browser/PluginScriptLoadingTest.ts
@@ -1,0 +1,42 @@
+import { describe, it } from '@ephox/bedrock-client';
+import { TinyHooks } from '@ephox/wrap-mcagar';
+import { assert } from 'chai';
+
+import Editor from 'hugerte/core/api/Editor';
+
+/**
+ * Regression test for the root cause behind the flaky webdriver
+ * `PlaceholderTest - TINY-3917: Check placeholder hides when inserting list via command`.
+ *
+ * When the distribution bundles are missing from the build (a `yarn ci` run that does
+ * not execute the rollup task), `js/hugerte/plugins/lists/plugin.js` is not produced.
+ * The editor then fails to load the lists plugin via the script-tag path, the load
+ * error is swallowed by the add-on loader, and the plugin never registers. Commands
+ * such as `InsertOrderedList` then silently no-op (no mutation, no `ExecCommand`
+ * event) which leaves e.g. the placeholder visible after the command.
+ *
+ * Note: this test deliberately does NOT import the lists Plugin module, so the plugin
+ * must be loaded from the served distribution exactly like a real user install.
+ */
+describe('browser.hugerte.plugins.lists.PluginScriptLoadingTest', () => {
+  const hook = TinyHooks.bddSetupLight<Editor>({
+    base_url: '/project/hugerte/js/hugerte',
+    plugins: 'lists',
+  }, []);
+
+  it('lists plugin bundle is served and loads via script to register commands', async () => {
+    // The plugin script must be present in the served distribution. A stale or
+    // incomplete build (rollup outputs missing) yields a 404 here, which used to
+    // silently disable the whole plugin for editors that load it from disk.
+    const res = await fetch('/project/hugerte/js/hugerte/plugins/lists/plugin.js', { cache: 'no-store' });
+    assert.equal(res.status, 200, 'js/hugerte/plugins/lists/plugin.js must be served by the test harness');
+
+    const editor = hook.editor();
+    assert.isOk(editor.plugins.lists, 'lists plugin should be active when loaded from the distribution');
+
+    // The command that the flaky placeholder test relies on must be registered,
+    // otherwise execCommand('InsertOrderedList') silently no-ops.
+    assert.isTrue(editor.execCommand('InsertOrderedList'), 'InsertOrderedList should be a supported command');
+    assert.equal(editor.getContent(), '<ol>\n<li>&nbsp;</li>\n</ol>', 'InsertOrderedList should convert the empty paragraph into an ordered list');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "eslint": "lerna exec --stream --no-bail -- eslint --max-warnings=0 src/**/*.ts",
     "start": "yarn -s hugerte-grunt start",
     "dev": "npm-run-all oxide-icons-build oxide-build -p tsc \"hugerte-grunt dev\"",
-    "ci": "npm-run-all -p oxide-ci oxide-icons-ci -p tsc \"hugerte-grunt dev\"",
+    "ci": "run-s oxide-ci oxide-icons-ci tsc \"hugerte-grunt dev\" \"hugerte-grunt rollup\"",
     "ci-seq": "run-s oxide-ci oxide-icons-ci tsc \"hugerte-grunt dev\"",
     "ci-all": "npm-run-all -p eslint ci -s hugerte-rollup",
     "ci-all-seq": "npm-run-all -p eslint ci-seq -s hugerte-rollup",


### PR DESCRIPTION
## Root cause (verified with CI instrumentation)

The flaky webdriver `PlaceholderTest - TINY-3917: Check placeholder hides when inserting list via command` is caused by **incomplete CI builds**, not by the placeholder or lists logic:

1. The CI workflow builds with `yarn ci`, which runs only `tsc` + `grunt dev` (static copies). It **never runs the rollup task**, so in a fresh checkout `js/hugerte/hugerte.js`, `js/hugerte/themes/*/theme.js`, `js/hugerte/models/*/model.js` and every `js/hugerte/plugins/*/plugin.js` are **not produced** (verified by reproducing `yarn ci` from a clean tree).
2. The PlaceholderTest's editor loads `plugins: 'lists'` from disk → `plugin.js` **404s** (verified in CI logs: `fetch(...plugins/lists/plugin.js) status=404`).
3. The add-on loader swallows the load failure (`Render.ts` `.catch(ErrorReporter.pluginLoadError)`), so the editor initialises **without** the lists plugin: `listsPlugin=false`, `insertorderedlist` command **never registered** (verified in CI diagnostics).
4. `editor.execCommand('InsertOrderedList')` then **silently no-ops** - no mutation, no `ExecCommand` event (the `Type.isFunction(func)` guard), returns `false` - so the placeholder stays visible forever → `Waited for 3000ms ... expected '' got 'Type here...'`.

It passed locally because stale rollup artifacts already existed in the working tree.

## Fix

- `package.json`: `yarn ci` now appends the rollup step (`run-s oxide-ci oxide-icons-ci tsc \"hugerte-grunt dev\" \"hugerte-grunt rollup\"`), producing a complete distribution in fresh checkouts.
- New deterministic browser regression test `PluginScriptLoadingTest` that fails when `plugins/lists/plugin.js` is not served (404) and passes when the plugin loads via script and registers `InsertOrderedList`.

Verified locally: PlaceholderTest (webdriver), PlaceholderVisuallyEmptyTest, 25 lists browser test files + all lists webdriver tests green; the regression test fails without the bundle and passes with it.